### PR TITLE
fix: add missed docsBranch config

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -62,6 +62,7 @@ module.exports = (context) => ({
     repo: 'vuepress/vuepress.github.io',
     editLinks: true,
     docsDir: 'docs',
+    docsBranch: 'docs',
     locales: {
       '/en/': {
         label: 'English',


### PR DESCRIPTION
__Edit this page on Github__ may cause a 404 error because of missing the docsBranch config.